### PR TITLE
Add CLI support to client

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,40 @@ uv run copick_server/server.py serve --dataset-ids 10440 --cors "*" --port 8017
 
 ### Launch a client
 
+#### Basic client
+
 ```bash
-uv run copick_server/client.py
+python -m copick_server.client
+```
+
+#### Client CLI
+
+The client now supports CLI commands for various operations. You can specify a different server URL with the `--base-url` option.
+
+```bash
+# Create an empty segmentation
+python -m copick_server.client create-segmentation \
+    --base-url "http://localhost:8017" \
+    --run-name 10440 \
+    --voxel-size 10.012 \
+    --user-id "myuser" \
+    --session-id "mysession" \
+    --name "membrane"
+```
+
+Using uv run:
+```bash
+uv run copick_server/client.py create-segmentation \
+    --base-url "http://localhost:8017" \
+    --run-name 10440 \
+    --voxel-size 10.012 \
+    --name "membrane"
+```
+
+Get CLI help:
+```bash
+python -m copick_server.client --help
+python -m copick_server.client create-segmentation --help
 ```
 
 ## Running Tests
@@ -62,6 +94,8 @@ pytest --cov=copick_server
 
 ## CLI Options
 
+### Server Options
+
 ```
 python -m copick_server.server serve --help
 ```
@@ -75,6 +109,22 @@ python -m copick_server.server serve --help
 | --host            | Bind socket to this host                               | 127.0.0.1     |
 | --port            | Bind socket to this port                               | 8000          |
 | --reload          | Enable auto-reload                                     | False         |
+
+### Client Options
+
+```
+python -m copick_server.client create-segmentation --help
+```
+
+| Option            | Description                                            | Default       |
+|-------------------|--------------------------------------------------------|---------------|
+| --base-url        | Base URL of the Copick server                          | http://localhost:8017 |
+| --run-name        | Name of the run to work with                           | (Required)    |
+| --voxel-size      | Voxel size to use                                      | (Required)    |
+| --user-id         | User ID for the segmentation                           | copickClient  |
+| --session-id      | Session ID for the segmentation                        | copickSession |
+| --name            | Name of the segmentation                               | (Required)    |
+| --multilabel      | Flag for multilabel segmentation                       | False         |
 
 ## References
 

--- a/copick_server/client.py
+++ b/copick_server/client.py
@@ -1,42 +1,134 @@
 import zarr
 import requests
 import numpy as np
+import click
 from fsspec import get_mapper
+from typing import Optional
 
-# First read the tomogram to get the shape
-store = get_mapper("http://localhost:8017/16463/Tomograms/VoxelSpacing10.012/wbp.zarr")
-tomo = zarr.open(store, mode='r')
-full_shape = tomo["0"].shape
-print(f"Tomogram shape: {full_shape}")
 
-# Example parameters
-voxel_size = 10.012
-user_id = "kisharrington"
-session_id = "copickServer"
-name = "membrane"  # This must match a pickable object in your config
-is_multilabel = False
+def create_empty_segmentation(base_url: str, run_name: str, voxel_size: float, user_id: str, session_id: str, name: str, is_multilabel: bool = False):
+    """Create an empty segmentation matching a tomogram's dimensions.
+    
+    Parameters
+    ----------
+    base_url : str
+        Base URL of the Copick server
+    run_name : str
+        Name of the run to work with
+    voxel_size : float
+        Voxel size to use
+    user_id : str
+        User ID for the segmentation
+    session_id : str
+        Session ID for the segmentation
+    name : str
+        Name of the segmentation (must match a pickable object in the config)
+    is_multilabel : bool, optional
+        Whether the segmentation is multilabel, by default False
+    """
+    # First read the tomogram to get the shape
+    store = get_mapper(f"{base_url}/{run_name}/Tomograms/VoxelSpacing{voxel_size}/wbp.zarr")
+    tomo = zarr.open(store, mode='r')
+    full_shape = tomo["0"].shape
+    print(f"Tomogram shape: {full_shape}")
 
-# Construct the segmentation filename
-seg_filename = f"{voxel_size}_{user_id}_{session_id}_{name}"
-if is_multilabel:
-    seg_filename += "-multilabel"
-seg_filename += ".zarr"
+    # Construct the segmentation filename
+    seg_filename = f"{voxel_size}_{user_id}_{session_id}_{name}"
+    if is_multilabel:
+        seg_filename += "-multilabel"
+    seg_filename += ".zarr"
 
-# Create segmentation data matching tomogram dimensions
-data = np.zeros(full_shape, dtype=np.uint8)  # for single label
+    # Create segmentation data matching tomogram dimensions
+    data = np.zeros(full_shape, dtype=np.uint8)  # for single label
 
-# Ensure the data is in C-contiguous memory layout
-data = np.ascontiguousarray(data)
+    # Ensure the data is in C-contiguous memory layout
+    data = np.ascontiguousarray(data)
 
-# Convert to bytes, preserving the shape information
-shape_header = np.array(data.shape, dtype=np.int64).tobytes()
-data_bytes = shape_header + data.tobytes()
+    # Convert to bytes, preserving the shape information
+    shape_header = np.array(data.shape, dtype=np.int64).tobytes()
+    data_bytes = shape_header + data.tobytes()
 
-# Send to server as a single request
-url = f"http://localhost:8017/16463/Segmentations/{seg_filename}"
-response = requests.put(url, data=data_bytes)
+    # Send to server as a single request
+    url = f"{base_url}/{run_name}/Segmentations/{seg_filename}"
+    response = requests.put(url, data=data_bytes)
 
-if response.status_code == 200:
-    print("Successfully wrote segmentation")
-else:
-    print(f"Failed to write segmentation: {response.status_code} - {response.text}")
+    if response.status_code == 200:
+        print("Successfully wrote segmentation")
+    else:
+        print(f"Failed to write segmentation: {response.status_code} - {response.text}")
+
+
+@click.group()
+@click.pass_context
+def cli(ctx):
+    pass
+
+
+@cli.command()
+@click.option(
+    "--base-url",
+    type=str,
+    default="http://localhost:8017",
+    help="Base URL of the Copick server",
+    show_default=True,
+)
+@click.option(
+    "--run-name",
+    type=str,
+    required=True,
+    help="Name of the run to work with",
+)
+@click.option(
+    "--voxel-size",
+    type=float,
+    required=True,
+    help="Voxel size to use",
+)
+@click.option(
+    "--user-id",
+    type=str,
+    default="copickClient",
+    help="User ID for the segmentation",
+    show_default=True,
+)
+@click.option(
+    "--session-id",
+    type=str,
+    default="copickSession",
+    help="Session ID for the segmentation",
+    show_default=True,
+)
+@click.option(
+    "--name",
+    type=str,
+    required=True,
+    help="Name of the segmentation (must match a pickable object in the config)",
+)
+@click.option(
+    "--multilabel",
+    is_flag=True,
+    help="Set this flag if the segmentation is multilabel",
+)
+@click.pass_context
+def create_segmentation(ctx, base_url: str, run_name: str, voxel_size: float, user_id: str, session_id: str, name: str, multilabel: bool):
+    """Create an empty segmentation matching a tomogram's dimensions."""
+    try:
+        create_empty_segmentation(
+            base_url=base_url,
+            run_name=run_name,
+            voxel_size=voxel_size,
+            user_id=user_id,
+            session_id=session_id,
+            name=name,
+            is_multilabel=multilabel
+        )
+    except Exception as e:
+        ctx.fail(f"Error creating segmentation: {str(e)}")
+
+
+def main():
+    cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/copick_server/demo_client.py
+++ b/copick_server/demo_client.py
@@ -1,0 +1,33 @@
+# Demo script to show the client CLI usage
+from copick_server.client import create_empty_segmentation
+
+# Example usage as a module
+def demo_client_module():
+    """Demo function showing how to use the client as a module"""
+    # Parameters
+    base_url = "http://localhost:8017"
+    run_name = "10440"
+    voxel_size = 10.012
+    user_id = "demoUser"
+    session_id = "demoSession"
+    name = "membrane"
+    is_multilabel = False
+    
+    # Create an empty segmentation
+    create_empty_segmentation(
+        base_url=base_url,
+        run_name=run_name,
+        voxel_size=voxel_size,
+        user_id=user_id,
+        session_id=session_id,
+        name=name,
+        is_multilabel=is_multilabel
+    )
+
+if __name__ == "__main__":
+    print("Running client demo as a module...")
+    demo_client_module()
+    
+    print("\nTo use the CLI directly, run one of the following commands:")
+    print("python -m copick_server.client create-segmentation --run-name 10440 --voxel-size 10.012 --name membrane")
+    print("uv run copick_server/client.py create-segmentation --base-url http://localhost:8017 --run-name 10440 --voxel-size 10.012 --name membrane")


### PR DESCRIPTION
This PR adds CLI support to the client with the following features:

- Updated `client.py` to support CLI commands with click
- Added the `create-segmentation` command to create an empty segmentation
- Made the server base URL configurable with default "http://localhost:8017"
- Added a `demo_client.py` file to demonstrate usage
- Updated README with client CLI documentation

### Usage Example

```bash
python -m copick_server.client create-segmentation \
    --base-url "http://localhost:8017" \
    --run-name 10440 \
    --voxel-size 10.012 \
    --name "membrane"
```

This follows a similar pattern to the server CLI implementation and complements the recently added dataset_ids support for the server.